### PR TITLE
Avoiding Adding Duplicate Label to sqlite db

### DIFF
--- a/sqlite-hf/src/lib.rs
+++ b/sqlite-hf/src/lib.rs
@@ -10,7 +10,9 @@ use std::io::BufReader;
 // create zero shot classification candidates
 fn create_db() -> sqlite::Connection {
     let db = sqlite::open(":memory:").unwrap();
-    db.execute("CREATE TABLE zeroshotcandidates (id INTEGER PRIMARY KEY, label TEXT)")
+    db.execute("CREATE TABLE IF NOT EXISTS zeroshotcandidates (id INTEGER PRIMARY KEY, label TEXT)")
+        .unwrap();
+    db.execute("DELETE FROM zeroshotcandidates")  
         .unwrap();
     db.execute("INSERT INTO zeroshotcandidates (label) VALUES ('rock')")
         .unwrap();


### PR DESCRIPTION
- first line in sql checks whether the table is present or not , if present then it will not create it 
- second line deletes every label and creates new label -- thus avoiding dupication
- now ,when we can `cargo run candidates` we only get label that are not duplicate